### PR TITLE
Add background jobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 FROM ruby:2.3
 MAINTAINER mail@carlosribeiro.me
 
+ENV BUNDLE_PATH /gems
+
 RUN apt-get update && apt-get install -y \
   build-essential \
   ghostscript \

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,9 @@ gem 'pg', '~> 0.18'
 gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0'
 gem 'sass-rails', '~> 5.0'
+gem 'sidekiq'
 gem 'simple_form'
+gem 'sinatra', '>= 2.0.0.beta2', require: false
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,6 +64,7 @@ GEM
       execjs
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.2)
+    connection_pool (2.2.0)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     devise (4.2.0)
@@ -119,6 +120,7 @@ GEM
     multi_json (1.12.1)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
+    mustermann (1.0.0.beta2)
     nio4r (1.2.1)
     nokogiri (1.6.8)
       mini_portile2 (~> 2.1.0)
@@ -150,6 +152,8 @@ GEM
       pry (~> 0.10)
     puma (3.5.2)
     rack (2.0.1)
+    rack-protection (2.0.0.beta2)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.0)
@@ -179,6 +183,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.3.1)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
     rspec-core (3.5.1)
@@ -207,6 +212,10 @@ GEM
       tilt (>= 1.1, < 3)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    sidekiq (4.1.2)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      redis (~> 3.2, >= 3.2.1)
     simple_form (3.2.1)
       actionpack (> 4, < 5.1)
       activemodel (> 4, < 5.1)
@@ -215,6 +224,11 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    sinatra (2.0.0.beta2)
+      mustermann (= 1.0.0.beta2)
+      rack (~> 2.0)
+      rack-protection (= 2.0.0.beta2)
+      tilt (~> 2.0)
     slop (3.6.0)
     spring (1.7.2)
     spring-watcher-listen (2.0.0)
@@ -275,8 +289,10 @@ DEPENDENCIES
   rspec-rails
   sass-rails (~> 5.0)
   shoulda-matchers
+  sidekiq
   simple_form
   simplecov
+  sinatra (>= 2.0.0.beta2)
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)
@@ -284,4 +300,4 @@ DEPENDENCIES
   web-console
 
 BUNDLED WITH
-   1.12.5
+   1.13.2

--- a/app/jobs/example_job.rb
+++ b/app/jobs/example_job.rb
@@ -1,0 +1,7 @@
+class ExampleJob < ApplicationJob
+  queue_as :default
+
+  def perform(*args)
+    Rails.logger.info 'OpensancaCertifier'
+  end
+end

--- a/app/jobs/example_job.rb
+++ b/app/jobs/example_job.rb
@@ -1,7 +1,7 @@
-class ExampleJob < ApplicationJob
-  queue_as :default
+class ExampleJob
+  include Sidekiq::Worker
 
-  def perform(*args)
+  def perform
     Rails.logger.info 'OpensancaCertifier'
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,6 @@ Dotenv::Railtie.load unless Rails.env.production?
 module OpensancaCertifier
   class Application < Rails::Application
     config.autoload_paths << Rails.root.join('lib')
+    config.active_job.queue_adapter = :sidekiq
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
+  mount Sidekiq::Web => '/sidekiq'
+
   devise_for :users, controllers: { omniauth_callbacks: 'omniauth_callbacks' }
 
   patch '/users/finish', to: 'users#finish', as: 'finish_user_signup'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,7 @@
+---
+:concurrency: 25
+:pidfile: ./tmp/pids/sidekiq.pid
+:logfile: ./log/sidekiq.log
+:queues:
+  - default
+  - [high_priority, 2]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,12 +13,35 @@ web:
     - 3000:3000
   volumes:
     - .:/var/app
+  volumes_from:
+    - gems
   command: rails s -b '0.0.0.0'
   links:
     - db
+    - redis
   environment:
     DB_USER: postgres
+    REDIS_URL: redis://redis:6379
 
+job:
+  build: .
+  volumes:
+    - .:/var/app
+  volumes_from:
+    - gems
+  command: sidekiq -C config/sidekiq.yml
+  links:
+    - db
+    - redis
+  environment:
+    DB_USER: postgres
+    REDIS_URL: redis://redis:6379
+
+gems:
+  image: busybox
+  log_driver: 'none'
+  volumes:
+    - /gems
 data:
   image: cogniteev/echo
   command: echo 'Data Container for PostgreSQL'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ db:
     - '5432'
   volumes_from:
     - data
+redis:
+  image: redis
 
 web:
   build: .

--- a/spec/jobs/example_job_spec.rb
+++ b/spec/jobs/example_job_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ExampleJob, type: :job do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
This PR will add the ability to process background jobs using Sidekiq.

To create a job, run:
`rails generate job JobName`
or via docker
`docker-compose run web rails generate job JobName`

and edit the job on:
`app/jobs/example_job.rb`.

To process the job async, only call
`JobName.perform_later`.

Docker files are already prepared to run it.
The docker workflow to start the app was changed:

```
docker-compose build
docker-compose run web bundle install
docker-compose run job bundle install
docker-compose bin/rake db:create db:migrate db:seed
docker-compose up
```

Fixes #13 
